### PR TITLE
Ensure bootsnap and psych work together

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,8 @@ gem "will_paginate", "~> 3.3.0"
 # gem 'bcrypt', '~> 3.1.7'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", ">= 1.4.2", require: false
+gem "bootsnap", "~> 1.8.0", require: false
+gem "psych", "~> 4.0", require: false
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development


### PR DESCRIPTION
Bootsnap 1.7 only works with psych 3, whereas bootsnap 1.8.0 only works with psych 4. Ensure the latter combination is used so build failures are avoided.
