### PR TITLE
Drop support for Ruby 2.5 and 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.7, "3.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,8 +13,8 @@ AllCops:
     - 'node_modules/**/*'
     - 'vendor/bundle/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.5
-  TargetRailsVersion: 6.0
+  TargetRubyVersion: 2.7
+  TargetRailsVersion: 6.1
 
 Rails:
   Enabled: true

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -36,7 +36,7 @@ class MainController < ApplicationController
     @updated_at = @players
       .flat_map(&:availabilities)
       .select { |it| playdate_ids.include? it.playdate_id }
-      .map(&:updated_at).compact.max
+      .filter_map(&:updated_at).max
 
     @content = render_to_string "feed_table", layout: false, formats: [:html]
     render layout: false


### PR DESCRIPTION
- Update RuboCop to target Ruby 2.7
- Also update RuboCop to target Rails 6.1, which is the Rails version used by playdate
- Drop Ruby 2.5 and 2.6 from the CI matrix
