### PR TITLE
Require at least Rails 7.0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", "~> 7.0.1"
+gem "rails", ["~> 7.0.3", ">= 7.0.3.1"]
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "~> 1.4"
 # Use Puma as the app server


### PR DESCRIPTION
Version 7.0.3.1 contains security fixes, so require at least that version.
