### PR TITLE
Keep i18n data consistent using i18n-tasks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,3 +46,5 @@ jobs:
         run: bundle exec rubocop -P
       - name: Run ERB Lint
         run: bundle exec erblint --lint-all
+      - name: Run i18n-tasks
+        run: bundle exec i18n-tasks health

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development do
   gem "web-console", "~> 4.0"
 
   gem "erb_lint", "~> 0.2.0", require: false
+  gem "i18n-tasks", "~> 1.0", require: false
   gem "rubocop", "~> 1.25", require: false
   gem "rubocop-performance", "~> 1.13", require: false
   gem "rubocop-rails", "~> 2.17", require: false

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,11 @@
+# The "main" locale.
+base_locale: en
+# Available locales.
+locales: [en, nl]
+
+# Read and write translations.
+data:
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    - config/locales/%{locale}.yml
+    - config/locales/*.%{locale}.yml

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -3,9 +3,17 @@ base_locale: en
 # Available locales.
 locales: [en, nl]
 
-# Read and write translations.
 data:
-  # Locale files or `File.find` patterns where translations are read from:
   read:
     - config/locales/%{locale}.yml
     - config/locales/*.%{locale}.yml
+
+ignore_unused:
+  - 'activerecord.errors.messages.*'
+  - 'date.*'
+  - 'datetime.*'
+  - 'errors.*'
+  - 'helpers.*'
+  - 'number.*'
+  - 'support.array.*'
+  - 'time.*'

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -2,37 +2,37 @@
 en:
   application:
     notice:
-      access_denied_no_admin: "Access denied: You are not an admin."
-      log_in_first: "Log in first to use Playdate."
+      access_denied_no_admin: 'Access denied: You are not an admin.'
+      log_in_first: Log in first to use Playdate.
   availabilities:
     create:
-      notice: "A new availability was successfully added."
+      notice: A new availability was successfully added.
     destroy:
-      notice: "The availability was successfully destroyed."
+      notice: The availability was successfully destroyed.
     update:
-      notice: "The availability was successfully edited."
+      notice: The availability was successfully edited.
   main:
     update:
-      notice: "Changes saved."
+      notice: Changes saved.
   playdates:
     alerts:
-      invalid_day: "Invalid day!"
-      invalid_period: "Invalid period!"
+      invalid_day: Invalid day!
+      invalid_period: Invalid period!
     create:
-      notice: "The new playdate was added."
+      notice: The new playdate was added.
     destroy:
-      notice: "The playdate was removed."
+      notice: The playdate was removed.
     notices:
-      saved_new_range: "Saved %{count}."
-      saved_none: "No new dates were added."
+      saved_new_range: Saved %{count}.
+      saved_none: No new dates were added.
     prune:
-      notice: "Old playdates have been cleaned up."
+      notice: Old playdates have been cleaned up.
   players:
     create:
-      notice: "Player was successfully created."
+      notice: Player was successfully created.
     destroy:
-      cannot_delete_self: "Cannot delete yourself"
-      failed: "Destroying the player failed."
-      notice: "Player was successfully destroyed."
+      cannot_delete_self: Cannot delete yourself
+      failed: Destroying the player failed.
+      notice: Player was successfully destroyed.
     update:
-      notice: "Player was successfully updated."
+      notice: Player was successfully updated.

--- a/config/locales/controllers.nl.yml
+++ b/config/locales/controllers.nl.yml
@@ -2,37 +2,37 @@
 nl:
   application:
     notice:
-      access_denied_no_admin: "Toegang geweigerd: Je bent geen beheerder."
-      log_in_first: "Log eerst in om Playdate te gebruiken."
+      access_denied_no_admin: 'Toegang geweigerd: Je bent geen beheerder.'
+      log_in_first: Log eerst in om Playdate te gebruiken.
   availabilities:
     create:
-      notice: "Een nieuwe beschikbaarheid is toegevoegd."
+      notice: Een nieuwe beschikbaarheid is toegevoegd.
     destroy:
-      notice: "De beschikbaarheid is verwijderd."
+      notice: De beschikbaarheid is verwijderd.
     update:
-      notice: "De beschikbaarheid is bijgewerkt."
+      notice: De beschikbaarheid is bijgewerkt.
   main:
     update:
-      notice: "Wijzigingen opgeslagen."
+      notice: Wijzigingen opgeslagen.
   playdates:
     alerts:
-      invalid_day: "Ongeldige dag!"
-      invalid_period: "Ongeldige periode!"
+      invalid_day: Ongeldige dag!
+      invalid_period: Ongeldige periode!
     create:
-      notice: "De nieuwe speeldag is toegevoegd."
+      notice: De nieuwe speeldag is toegevoegd.
     destroy:
-      notice: "De speeldag is verwijderd."
+      notice: De speeldag is verwijderd.
     notices:
       saved_new_range: "%{count} opgeslagen."
-      saved_none: "Er zijn geen nieuwe datums toegevoegd."
+      saved_none: Er zijn geen nieuwe datums toegevoegd.
     prune:
-      notice: "Oude speeldagen zijn opgeruimd."
+      notice: Oude speeldagen zijn opgeruimd.
   players:
     create:
-      notice: "Speler is toegevoegd."
+      notice: Speler is toegevoegd.
     destroy:
-      cannot_delete_self: "Je kunt jezelf niet verwijderen"
-      failed: "Verwijderen van de speler is mislukt."
-      notice: "De speler is verwijderd."
+      cannot_delete_self: Je kunt jezelf niet verwijderen
+      failed: Verwijderen van de speler is mislukt.
+      notice: De speler is verwijderd.
     update:
-      notice: "De speler is bijgewerkt."
+      notice: De speler is bijgewerkt.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+  hello: Hello world

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,8 +5,8 @@ en:
       messages:
         record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: Cannot delete record because a dependent %{record} exists
           has_many: Cannot delete record because dependent %{record} exist
+          has_one: Cannot delete record because a dependent %{record} exists
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -75,36 +75,36 @@ en:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_seconds:
-        one: less than 1 second
-        other: less than %{count} seconds
       less_than_x_minutes:
         one: less than a minute
         other: less than %{count} minutes
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
-      x_minutes:
-        one: 1 minute
-        other: "%{count} minutes"
       x_days:
         one: 1 day
         other: "%{count} days"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
       x_months:
         one: 1 month
         other: "%{count} months"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_years:
         one: 1 year
         other: "%{count} years"
     prompts:
-      second: Second
-      minute: Minute
-      hour: Hour
       day: Day
+      hour: Hour
+      minute: Minute
       month: Month
+      second: Second
       year: Year
   errors:
     format: "%{attribute} %{message}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,217 @@
 ---
 en:
-  hello: Hello world
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validation failed: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    - 
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    - 
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+    prompts:
+      second: Second
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      in: must be in %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -131,10 +131,10 @@ nl:
       required: moet bestaan
       taken: is al in gebruik
       too_long:
-        one: is te lang (maximaal %{count} teken)
+        one: is te lang (maximaal 1 teken)
         other: is te lang (maximaal %{count} tekens)
       too_short:
-        one: is te kort (minimaal %{count} teken)
+        one: is te kort (minimaal 1 teken)
         other: is te kort (minimaal %{count} tekens)
       wrong_length:
         one: heeft onjuiste lengte (moet 1 teken lang zijn)

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -24,9 +24,7 @@ nl:
     currency:
       format:
         format: "%u %n"
-        unit: !binary |
-          4oKs
-
+        unit: "€"
         separator: ","
         precision: 2
         delimiter: .

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -118,6 +118,7 @@ nl:
       exclusion: is gereserveerd
       greater_than: moet groter zijn dan %{count}
       greater_than_or_equal_to: moet groter dan of gelijk zijn aan %{count}
+      in: moet in %{count} vallen
       inclusion: is niet in de lijst opgenomen
       invalid: is ongeldig
       less_than: moet minder zijn dan %{count}
@@ -164,6 +165,7 @@ nl:
     format:
       delimiter: "."
       precision: 2
+      round_mode: default
       separator: ","
       significant: false
       strip_insignificant_zeros: false
@@ -188,9 +190,11 @@ nl:
           byte:
             one: byte
             other: bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
+          pb: PB
           tb: TB
     percentage:
       format:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,88 +1,34 @@
-# Dutch translation in YML by Ariejan de Vroom <ariejan@ariejan.net>
-#  - Sponsored by Kabisa ICT - http://kabisa.nl
-#
-# Fully compatible with Translate (the Rails translation plugin)
-#  - http://developer.newsdesk.se/2009/01/21/translate-new-rails-i18n-plugin-with-a-nice-web-ui/
 ---
 nl:
-  number:
-    format:
-      separator: ","
-      precision: 2
-      delimiter: .
-    human:
-      storage_units:
-        format: "%n %u"
-        units:
-          kb: KB
-          tb: TB
-          gb: GB
-          byte:
-            one: Byte
-            other: Bytes
-          mb: MB
-    currency:
-      format:
-        format: "%u %n"
-        unit: "€"
-        separator: ","
-        precision: 2
-        delimiter: .
   activerecord:
     errors:
       messages:
-        greater_than_or_equal_to: moet groter of gelijk zijn aan {{count}}
-        less_than_or_equal_to: moet minder of gelijk zijn aan {{count}}
-        confirmation: komt niet met de bevestiging overeen
+        accepted: moet geaccepteerd worden
         blank: mag niet blanco zijn
+        confirmation: komt niet met de bevestiging overeen
+        empty: mag niet leeg zijn
+        equal_to: moet gelijk zijn aan {{count}}
+        even: moet even zijn
         exclusion: is gereserveerd
+        greater_than: moet groter zijn dan {{count}}
+        greater_than_or_equal_to: moet groter of gelijk zijn aan {{count}}
+        inclusion: is niet opgenomen in de lijst
         invalid: is ongeldig
-        record_invalid: is ongeldig
+        less_than: moet minder zijn dan {{count}}
+        less_than_or_equal_to: moet minder of gelijk zijn aan {{count}}
+        not_a_number: is geen getal
         odd: moet oneven zijn
+        record_invalid: is ongeldig
+        taken: is al in gebruik
+        too_long: is te lang (maximum is {{count}} tekens)
         too_short: is te kort (minimum is {{count}} tekens)
         wrong_length: heeft de verkeerde lengte (moet {{count}} tekens zijn)
-        empty: mag niet leeg zijn
-        even: moet even zijn
-        less_than: moet minder zijn dan {{count}}
-        equal_to: moet gelijk zijn aan {{count}}
-        greater_than: moet groter zijn dan {{count}}
-        accepted: moet geaccepteerd worden
-        too_long: is te lang (maximum is {{count}} tekens)
-        taken: is al in gebruik
-        inclusion: is niet opgenomen in de lijst
-        not_a_number: is geen getal
       template:
-        body: "Controleer alstublieft de volgende velden:"
+        body: 'Controleer alstublieft de volgende velden:'
         header:
-          one: "Kon dit {{model}} object niet opslaan: 1 fout."
-          other: "Kon dit {{model}} niet opslaan: {{count}} fouten."
-  time:
-    am: "'s ochtends"
-    formats:
-      default: "%a %d %b %Y %H:%M:%S %Z"
-      time: "%H:%M"
-      short: "%d %b %H:%M"
-      only_second: "%S"
-      datetime:
-        formats:
-          default: "%d-%m-%YT%H:%M:%S%Z"
-      long: "%d %B %Y %H:%M"
-    pm: "'s middags"
+          one: 'Kon dit {{model}} object niet opslaan: 1 fout.'
+          other: 'Kon dit {{model}} niet opslaan: {{count}} fouten.'
   date:
-    month_names:
-    -
-    - januari
-    - februari
-    - maart
-    - april
-    - mei
-    - juni
-    - juli
-    - augustus
-    - september
-    - oktober
-    - november
-    - december
     abbr_day_names:
     - zon
     - maa
@@ -91,23 +37,6 @@ nl:
     - don
     - vri
     - zat
-    order:
-    - :day
-    - :month
-    - :year
-    formats:
-      only_day: "%e"
-      default: "%d/%m/%Y"
-      short: "%e %b"
-      long: "%e %B %Y"
-    day_names:
-    - zondag
-    - maandag
-    - dinsdag
-    - woensdag
-    - donderdag
-    - vrijdag
-    - zaterdag
     abbr_month_names:
     -
     - jan
@@ -122,50 +51,116 @@ nl:
     - okt
     - nov
     - dec
-  support:
-    array:
-      words_connector: ", "
-      two_words_connector: " en "
-      last_word_connector: " en "
+    day_names:
+    - zondag
+    - maandag
+    - dinsdag
+    - woensdag
+    - donderdag
+    - vrijdag
+    - zaterdag
+    formats:
+      default: "%d/%m/%Y"
+      long: "%e %B %Y"
+      only_day: "%e"
+      short: "%e %b"
+    month_names:
+    -
+    - januari
+    - februari
+    - maart
+    - april
+    - mei
+    - juni
+    - juli
+    - augustus
+    - september
+    - oktober
+    - november
+    - december
+    order:
+    - :day
+    - :month
+    - :year
   datetime:
-    format:
-      default: "%Y-%m-%dT%H:%M:%S%Z"
-    prompts:
-      minute: minuut
-      second: seconden
-      month: maand
-      hour: uur
-      day: dag
-      year: jaar
     distance_in_words:
+      about_x_hours:
+        one: ongeveer Ã©Ã©n uur
+        other: ongeveer {{count}} uur
+      about_x_months:
+        one: ongeveer Ã©Ã©n maand
+        other: ongeveer {{count}} maanden
+      about_x_years:
+        one: ongeveer Ã©Ã©n jaar
+        other: ongeveer {{count}} jaren
+      half_a_minute: halve minuut
       less_than_x_minutes:
-        one: "minder dan \xC3\xA9\xC3\xA9n minuut"
+        one: minder dan Ã©Ã©n minuut
         other: minder dan {{count}} minuten
+      less_than_x_seconds:
+        one: minder dan Ã©Ã©n seconde
+        other: minder dan {{count}} seconden
+      over_x_years:
+        one: langer dan Ã©Ã©n jaar
+        other: langer {{count}} jaar
       x_days:
         one: 1 dag
         other: "{{count}} dagen"
-      x_seconds:
-        one: 1 seconde
-        other: "{{count}} seconden"
-      about_x_hours:
-        one: "ongeveer \xC3\xA9\xC3\xA9n uur"
-        other: ongeveer {{count}} uur
-      less_than_x_seconds:
-        one: "minder dan \xC3\xA9\xC3\xA9n seconde"
-        other: minder dan {{count}} seconden
-      x_months:
-        one: 1 maand
-        other: "{{count}} maanden"
       x_minutes:
         one: 1 minuut
         other: "{{count}} minuten"
-      about_x_years:
-        one: "ongeveer \xC3\xA9\xC3\xA9n jaar"
-        other: ongeveer {{count}} jaren
-      about_x_months:
-        one: "ongeveer \xC3\xA9\xC3\xA9n maand"
-        other: ongeveer {{count}} maanden
-      over_x_years:
-        one: "langer dan \xC3\xA9\xC3\xA9n jaar"
-        other: langer {{count}} jaar
-      half_a_minute: halve minuut
+      x_months:
+        one: 1 maand
+        other: "{{count}} maanden"
+      x_seconds:
+        one: 1 seconde
+        other: "{{count}} seconden"
+    format:
+      default: "%Y-%m-%dT%H:%M:%S%Z"
+    prompts:
+      day: dag
+      hour: uur
+      minute: minuut
+      month: maand
+      second: seconden
+      year: jaar
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+    human:
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+  support:
+    array:
+      last_word_connector: " en "
+      two_words_connector: " en "
+      words_connector: ", "
+  time:
+    am: "'s ochtends"
+    formats:
+      datetime:
+        formats:
+          default: "%d-%m-%YT%H:%M:%S%Z"
+      default: "%a %d %b %Y %H:%M:%S %Z"
+      long: "%d %B %Y %H:%M"
+      only_second: "%S"
+      short: "%d %b %H:%M"
+      time: "%H:%M"
+    pm: "'s middags"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,11 +1,12 @@
+---
 nl:
   activerecord:
     errors:
       messages:
         record_invalid: 'Validatie mislukt: %{errors}'
         restrict_dependent_destroy:
-          has_one: Kan item niet verwijderen omdat %{record} afhankelijk is
           has_many: Kan item niet verwijderen omdat afhankelijke %{record} bestaan
+          has_one: Kan item niet verwijderen omdat %{record} afhankelijk is
   date:
     abbr_day_names:
     - zo
@@ -16,7 +17,7 @@ nl:
     - vr
     - za
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - mrt
@@ -42,7 +43,7 @@ nl:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - januari
     - februari
     - maart
@@ -74,36 +75,36 @@ nl:
         one: bijna een jaar
         other: bijna %{count} jaar
       half_a_minute: een halve minuut
-      less_than_x_seconds:
-        one: minder dan een seconde
-        other: minder dan %{count} seconden
       less_than_x_minutes:
         one: minder dan een minuut
         other: minder dan %{count} minuten
+      less_than_x_seconds:
+        one: minder dan een seconde
+        other: minder dan %{count} seconden
       over_x_years:
         one: meer dan een jaar
         other: meer dan %{count} jaar
-      x_seconds:
-        one: 1 seconde
-        other: "%{count} seconden"
-      x_minutes:
-        one: 1 minuut
-        other: "%{count} minuten"
       x_days:
         one: 1 dag
         other: "%{count} dagen"
+      x_minutes:
+        one: 1 minuut
+        other: "%{count} minuten"
       x_months:
         one: 1 maand
         other: "%{count} maanden"
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} seconden"
       x_years:
         one: 1 jaar
         other: "%{count} jaar"
     prompts:
-      second: seconde
-      minute: minuut
-      hour: uur
       day: dag
+      hour: uur
+      minute: minuut
       month: maand
+      second: seconde
       year: jaar
   errors:
     format: "%{attribute} %{message}"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,47 +1,25 @@
----
 nl:
   activerecord:
     errors:
       messages:
-        accepted: moet geaccepteerd worden
-        blank: mag niet blanco zijn
-        confirmation: komt niet met de bevestiging overeen
-        empty: mag niet leeg zijn
-        equal_to: moet gelijk zijn aan {{count}}
-        even: moet even zijn
-        exclusion: is gereserveerd
-        greater_than: moet groter zijn dan {{count}}
-        greater_than_or_equal_to: moet groter of gelijk zijn aan {{count}}
-        inclusion: is niet opgenomen in de lijst
-        invalid: is ongeldig
-        less_than: moet minder zijn dan {{count}}
-        less_than_or_equal_to: moet minder of gelijk zijn aan {{count}}
-        not_a_number: is geen getal
-        odd: moet oneven zijn
-        record_invalid: is ongeldig
-        taken: is al in gebruik
-        too_long: is te lang (maximum is {{count}} tekens)
-        too_short: is te kort (minimum is {{count}} tekens)
-        wrong_length: heeft de verkeerde lengte (moet {{count}} tekens zijn)
-      template:
-        body: 'Controleer alstublieft de volgende velden:'
-        header:
-          one: 'Kon dit {{model}} object niet opslaan: 1 fout.'
-          other: 'Kon dit {{model}} niet opslaan: {{count}} fouten.'
+        record_invalid: 'Validatie mislukt: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Kan item niet verwijderen omdat %{record} afhankelijk is
+          has_many: Kan item niet verwijderen omdat afhankelijke %{record} bestaan
   date:
     abbr_day_names:
-    - zon
-    - maa
-    - din
-    - woe
-    - don
-    - vri
-    - zat
+    - zo
+    - ma
+    - di
+    - wo
+    - do
+    - vr
+    - za
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
-    - mar
+    - mrt
     - apr
     - mei
     - jun
@@ -60,12 +38,11 @@ nl:
     - vrijdag
     - zaterdag
     formats:
-      default: "%d/%m/%Y"
+      default: "%d-%m-%Y"
       long: "%e %B %Y"
-      only_day: "%e"
       short: "%e %b"
     month_names:
-    -
+    - 
     - januari
     - februari
     - maart
@@ -85,45 +62,94 @@ nl:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: ongeveer Ã©Ã©n uur
-        other: ongeveer {{count}} uur
+        one: ongeveer een uur
+        other: ongeveer %{count} uur
       about_x_months:
-        one: ongeveer Ã©Ã©n maand
-        other: ongeveer {{count}} maanden
+        one: ongeveer een maand
+        other: ongeveer %{count} maanden
       about_x_years:
-        one: ongeveer Ã©Ã©n jaar
-        other: ongeveer {{count}} jaren
-      half_a_minute: halve minuut
-      less_than_x_minutes:
-        one: minder dan Ã©Ã©n minuut
-        other: minder dan {{count}} minuten
+        one: ongeveer een jaar
+        other: ongeveer %{count} jaar
+      almost_x_years:
+        one: bijna een jaar
+        other: bijna %{count} jaar
+      half_a_minute: een halve minuut
       less_than_x_seconds:
-        one: minder dan Ã©Ã©n seconde
-        other: minder dan {{count}} seconden
+        one: minder dan een seconde
+        other: minder dan %{count} seconden
+      less_than_x_minutes:
+        one: minder dan een minuut
+        other: minder dan %{count} minuten
       over_x_years:
-        one: langer dan Ã©Ã©n jaar
-        other: langer {{count}} jaar
-      x_days:
-        one: 1 dag
-        other: "{{count}} dagen"
-      x_minutes:
-        one: 1 minuut
-        other: "{{count}} minuten"
-      x_months:
-        one: 1 maand
-        other: "{{count}} maanden"
+        one: meer dan een jaar
+        other: meer dan %{count} jaar
       x_seconds:
         one: 1 seconde
-        other: "{{count}} seconden"
-    format:
-      default: "%Y-%m-%dT%H:%M:%S%Z"
+        other: "%{count} seconden"
+      x_minutes:
+        one: 1 minuut
+        other: "%{count} minuten"
+      x_days:
+        one: 1 dag
+        other: "%{count} dagen"
+      x_months:
+        one: 1 maand
+        other: "%{count} maanden"
+      x_years:
+        one: 1 jaar
+        other: "%{count} jaar"
     prompts:
-      day: dag
-      hour: uur
+      second: seconde
       minute: minuut
+      hour: uur
+      day: dag
       month: maand
-      second: seconden
       year: jaar
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: moet worden geaccepteerd
+      blank: moet opgegeven zijn
+      confirmation: komt niet overeen met %{attribute}
+      empty: moet opgegeven zijn
+      equal_to: moet gelijk zijn aan %{count}
+      even: moet even zijn
+      exclusion: is gereserveerd
+      greater_than: moet groter zijn dan %{count}
+      greater_than_or_equal_to: moet groter dan of gelijk zijn aan %{count}
+      inclusion: is niet in de lijst opgenomen
+      invalid: is ongeldig
+      less_than: moet minder zijn dan %{count}
+      less_than_or_equal_to: moet minder dan of gelijk zijn aan %{count}
+      model_invalid: 'Validatie mislukt: %{errors}'
+      not_a_number: is geen getal
+      not_an_integer: moet een geheel getal zijn
+      odd: moet oneven zijn
+      other_than: moet anders zijn dan %{count}
+      present: moet leeg zijn
+      required: moet bestaan
+      taken: is al in gebruik
+      too_long:
+        one: is te lang (maximaal %{count} teken)
+        other: is te lang (maximaal %{count} tekens)
+      too_short:
+        one: is te kort (minimaal %{count} teken)
+        other: is te kort (minimaal %{count} tekens)
+      wrong_length:
+        one: heeft onjuiste lengte (moet 1 teken lang zijn)
+        other: heeft onjuiste lengte (moet %{count} tekens lang zijn)
+    template:
+      body: 'Er zijn problemen met de volgende velden:'
+      header:
+        one: "%{model} niet opgeslagen: 1 fout gevonden"
+        other: "%{model} niet opgeslagen: %{count} fouten gevonden"
+  helpers:
+    select:
+      prompt: Maak een keuze
+    submit:
+      create: "%{model} toevoegen"
+      submit: "%{model} opslaan"
+      update: "%{model} bijwerken"
   number:
     currency:
       format:
@@ -131,22 +157,47 @@ nl:
         format: "%u %n"
         precision: 2
         separator: ","
+        significant: false
+        strip_insignificant_zeros: false
         unit: "€"
     format:
       delimiter: "."
       precision: 2
       separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miljard
+          million: miljoen
+          quadrillion: biljard
+          thousand: duizend
+          trillion: biljoen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         format: "%n %u"
         units:
           byte:
-            one: Byte
-            other: Bytes
+            one: byte
+            other: bytes
           gb: GB
           kb: KB
           mb: MB
           tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
   support:
     array:
       last_word_connector: " en "
@@ -155,12 +206,7 @@ nl:
   time:
     am: "'s ochtends"
     formats:
-      datetime:
-        formats:
-          default: "%d-%m-%YT%H:%M:%S%Z"
       default: "%a %d %b %Y %H:%M:%S %Z"
       long: "%d %B %Y %H:%M"
-      only_second: "%S"
       short: "%d %b %H:%M"
-      time: "%H:%M"
     pm: "'s middags"


### PR DESCRIPTION
- Add i18n-tasks gem
- Fix currency unit translation so its encoding is UTF-8
- Configure i18n-tasks
- Normalize translations
- Update default Rails translations from rails-i18n
- Normalize locale files again
- Consider default Rails translations used
- Make interpolation consistent
- Provide missing Dutch translations
- Run i18n-tasks as part of the lint job in GitHub Actions
