### PR TITLE
Use responders gem to clean up flash messages

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,11 +41,3 @@ RSpec/LeakyConstantDeclaration:
 
 RSpec/MultipleExpectations:
   Max: 5
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: SafeAutocorrect.
-Rails/ActionControllerFlashBeforeRender:
-  Exclude:
-    - 'app/controllers/availabilities_controller.rb'
-    - 'app/controllers/playdates_controller.rb'
-    - 'app/controllers/players_controller.rb'

--- a/app/assets/stylesheets/playdate.css
+++ b/app/assets/stylesheets/playdate.css
@@ -159,7 +159,7 @@ label {
   color: green;
 }
 
-.flash-error {
+.flash-alert {
   color: red;
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
+require "application_responder"
+
 # Main controller superclass.
 class ApplicationController < ActionController::Base
+  self.responder = ApplicationResponder
+  respond_to :html
+
   before_action :load_current_user
 
   helper_method :current_user

--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -16,18 +16,17 @@ class AvailabilitiesController < ApplicationController
 
   def create
     @availability = @playdate.availabilities.build(new_availability_params)
-    flash[:notice] = t(".notice") if @availability.save
+    @availability.save
     respond_with @availability, location: playdate_path(@playdate)
   end
 
   def update
-    flash[:notice] = t(".notice") if @availability.update(edit_availability_params)
+    @availability.update(edit_availability_params)
     respond_with @availability, location: playdate_path(@playdate)
   end
 
   def destroy
     @availability.destroy
-    flash[:notice] = t(".notice")
     respond_with @availability, location: playdate_path(@playdate)
   end
 

--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -2,7 +2,6 @@
 
 # Administrative controller for editing availabilities.
 class AvailabilitiesController < ApplicationController
-  respond_to :html
   before_action :authorize_admin
   before_action :load_resource, only: [:edit, :update, :destroy]
   before_action :load_playdate, only: [:new, :create]

--- a/app/controllers/playdates_controller.rb
+++ b/app/controllers/playdates_controller.rb
@@ -36,7 +36,7 @@ class PlaydatesController < ApplicationController
 
   def destroy
     @playdate = Playdate.find(params[:id])
-    flash[:notice] = t(".notice") if @playdate.destroy
+    @playdate.destroy
     respond_with @playdate, location: playdates_path
   end
 

--- a/app/controllers/playdates_controller.rb
+++ b/app/controllers/playdates_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PlaydatesController < ApplicationController
-  respond_to :html
   before_action :authorize_admin
 
   PERIOD_THIS_MONTH = 1

--- a/app/controllers/playdates_controller.rb
+++ b/app/controllers/playdates_controller.rb
@@ -25,7 +25,7 @@ class PlaydatesController < ApplicationController
   def create
     if params[:playdate]
       @playdate = Playdate.new(playdate_params)
-      flash[:notice] = t(".notice") if @playdate.save
+      @playdate.save
       respond_with @playdate, location: playdates_path
     else
       @period = (params[:period] || PERIOD_THIS_MONTH).to_i

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PlayersController < ApplicationController
-  respond_to :html
   before_action :authorize_admin
 
   def index

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -32,13 +32,13 @@ class PlayersController < ApplicationController
     @player = Player.find(params[:id])
 
     if @player == current_user
-      flash[:error] = t(".cannot_delete_self")
+      flash[:alert] = t(".cannot_delete_self")
       redirect_to(players_url)
     else
       if @player.destroy
         flash[:notice] = t(".notice")
       else
-        flash[:error] = t(".failed")
+        flash[:alert] = t(".failed")
       end
       respond_with @player, location: players_path
     end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -17,14 +17,13 @@ class PlayersController < ApplicationController
 
   def create
     @player = Player.new(player_params)
-    flash[:notice] = t(".notice") if @player.save
+    @player.save
     respond_with @player, location: players_path
   end
 
   def update
     @player = Player.find(params[:id])
-
-    flash[:notice] = t(".notice") if @player.update player_params
+    @player.update player_params
     respond_with @player, location: players_path
   end
 
@@ -35,11 +34,7 @@ class PlayersController < ApplicationController
       flash[:alert] = t(".cannot_delete_self")
       redirect_to(players_url)
     else
-      if @player.destroy
-        flash[:notice] = t(".notice")
-      else
-        flash[:alert] = t(".failed")
-      end
+      @player.destroy
       respond_with @player, location: players_path
     end
   end

--- a/app/views/shared/_showflash.html.erb
+++ b/app/views/shared/_showflash.html.erb
@@ -1,6 +1,6 @@
 <% if flash[:notice].present? %>
   <p class="flash-notice"><%= flash[:notice] %></p>
 <% end %>
-<% if flash[:error].present? %>
-  <p class="flash-error"><%= flash[:error] %></p>
+<% if flash[:alert].present? %>
+  <p class="flash-alert"><%= flash[:error] %></p>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,9 @@ Bundler.require(*Rails.groups)
 
 module PlayDate
   class Application < Rails::Application
+    # Use the responders controller from the responders gem
+    config.app_generators.scaffold_controller :responders_controller
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -13,6 +13,7 @@ ignore_unused:
   - 'date.*'
   - 'datetime.*'
   - 'errors.*'
+  - 'flash.*'
   - 'helpers.*'
   - 'number.*'
   - 'support.array.*'

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -24,11 +24,5 @@ en:
     prune:
       notice: Old playdates have been cleaned up.
   players:
-    create:
-      notice: Player was successfully created.
     destroy:
       cannot_delete_self: Cannot delete yourself
-      failed: Destroying the player failed.
-      notice: Player was successfully destroyed.
-    update:
-      notice: Player was successfully updated.

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -18,8 +18,6 @@ en:
     alerts:
       invalid_day: Invalid day!
       invalid_period: Invalid period!
-    create:
-      notice: The new playdate was added.
     destroy:
       notice: The playdate was removed.
     notices:

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -18,8 +18,6 @@ en:
     alerts:
       invalid_day: Invalid day!
       invalid_period: Invalid period!
-    destroy:
-      notice: The playdate was removed.
     notices:
       saved_new_range: Saved %{count}.
       saved_none: No new dates were added.

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -4,13 +4,6 @@ en:
     notice:
       access_denied_no_admin: 'Access denied: You are not an admin.'
       log_in_first: Log in first to use Playdate.
-  availabilities:
-    create:
-      notice: A new availability was successfully added.
-    destroy:
-      notice: The availability was successfully destroyed.
-    update:
-      notice: The availability was successfully edited.
   main:
     update:
       notice: Changes saved.

--- a/config/locales/controllers.nl.yml
+++ b/config/locales/controllers.nl.yml
@@ -18,8 +18,6 @@ nl:
     alerts:
       invalid_day: Ongeldige dag!
       invalid_period: Ongeldige periode!
-    destroy:
-      notice: De speeldag is verwijderd.
     notices:
       saved_new_range: "%{count} opgeslagen."
       saved_none: Er zijn geen nieuwe datums toegevoegd.

--- a/config/locales/controllers.nl.yml
+++ b/config/locales/controllers.nl.yml
@@ -18,8 +18,6 @@ nl:
     alerts:
       invalid_day: Ongeldige dag!
       invalid_period: Ongeldige periode!
-    create:
-      notice: De nieuwe speeldag is toegevoegd.
     destroy:
       notice: De speeldag is verwijderd.
     notices:

--- a/config/locales/controllers.nl.yml
+++ b/config/locales/controllers.nl.yml
@@ -24,11 +24,5 @@ nl:
     prune:
       notice: Oude speeldagen zijn opgeruimd.
   players:
-    create:
-      notice: Speler is toegevoegd.
     destroy:
       cannot_delete_self: Je kunt jezelf niet verwijderen
-      failed: Verwijderen van de speler is mislukt.
-      notice: De speler is verwijderd.
-    update:
-      notice: De speler is bijgewerkt.

--- a/config/locales/controllers.nl.yml
+++ b/config/locales/controllers.nl.yml
@@ -4,13 +4,6 @@ nl:
     notice:
       access_denied_no_admin: 'Toegang geweigerd: Je bent geen beheerder.'
       log_in_first: Log eerst in om Playdate te gebruiken.
-  availabilities:
-    create:
-      notice: Een nieuwe beschikbaarheid is toegevoegd.
-    destroy:
-      notice: De beschikbaarheid is verwijderd.
-    update:
-      notice: De beschikbaarheid is bijgewerkt.
   main:
     update:
       notice: Wijzigingen opgeslagen.

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -1,0 +1,12 @@
+en:
+  flash:
+    actions:
+      create:
+        notice: '%{resource_name} was successfully created.'
+        # alert: '%{resource_name} could not be created.'
+      update:
+        notice: '%{resource_name} was successfully updated.'
+        # alert: '%{resource_name} could not be updated.'
+      destroy:
+        notice: '%{resource_name} was successfully destroyed.'
+        alert: '%{resource_name} could not be destroyed.'

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -12,3 +12,5 @@ en:
     playdates:
       create:
         notice: The new playdate was added.
+      destroy:
+        notice: The playdate was removed.

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -9,3 +9,6 @@ en:
         notice: "%{resource_name} was successfully destroyed."
       update:
         notice: "%{resource_name} was successfully updated."
+    playdates:
+      create:
+        notice: The new playdate was added.

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -14,3 +14,11 @@ en:
         notice: The new playdate was added.
       destroy:
         notice: The playdate was removed.
+    players:
+      create:
+        notice: Player was successfully created.
+      destroy:
+        failed: Destroying the player failed.
+        notice: Player was successfully destroyed.
+      update:
+        notice: Player was successfully updated.

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -1,12 +1,11 @@
+---
 en:
   flash:
     actions:
       create:
-        notice: '%{resource_name} was successfully created.'
-        # alert: '%{resource_name} could not be created.'
-      update:
-        notice: '%{resource_name} was successfully updated.'
-        # alert: '%{resource_name} could not be updated.'
+        notice: "%{resource_name} was successfully created."
       destroy:
-        notice: '%{resource_name} was successfully destroyed.'
-        alert: '%{resource_name} could not be destroyed.'
+        alert: "%{resource_name} could not be destroyed."
+        notice: "%{resource_name} was successfully destroyed."
+      update:
+        notice: "%{resource_name} was successfully updated."

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -9,6 +9,13 @@ en:
         notice: "%{resource_name} was successfully destroyed."
       update:
         notice: "%{resource_name} was successfully updated."
+    availabilities:
+      create:
+        notice: A new availability was successfully added.
+      destroy:
+        notice: The availability was successfully destroyed.
+      update:
+        notice: The availability was successfully edited.
     playdates:
       create:
         notice: The new playdate was added.

--- a/config/locales/responders.nl.yml
+++ b/config/locales/responders.nl.yml
@@ -9,6 +9,13 @@ nl:
         notice: "%{resource_name} is verwijderd."
       update:
         notice: "%{resource_name} is bijgewerkt."
+    availabilities:
+      create:
+        notice: Een nieuwe beschikbaarheid is toegevoegd.
+      destroy:
+        notice: De beschikbaarheid is verwijderd.
+      update:
+        notice: De beschikbaarheid is bijgewerkt.
     playdates:
       create:
         notice: De nieuwe speeldag is toegevoegd.

--- a/config/locales/responders.nl.yml
+++ b/config/locales/responders.nl.yml
@@ -14,3 +14,11 @@ nl:
         notice: De nieuwe speeldag is toegevoegd.
       destroy:
         notice: De speeldag is verwijderd.
+    players:
+      create:
+        notice: Speler is toegevoegd.
+      destroy:
+        failed: Verwijderen van de speler is mislukt.
+        notice: De speler is verwijderd.
+      update:
+        notice: De speler is bijgewerkt.

--- a/config/locales/responders.nl.yml
+++ b/config/locales/responders.nl.yml
@@ -1,0 +1,11 @@
+---
+nl:
+  flash:
+    actions:
+      create:
+        notice: "%{resource_name} is aangemaakt."
+      destroy:
+        alert: "%{resource_name} kon niet verwijderd worden."
+        notice: "%{resource_name} is verwijderd."
+      update:
+        notice: "%{resource_name} is bijgewerkt."

--- a/config/locales/responders.nl.yml
+++ b/config/locales/responders.nl.yml
@@ -9,3 +9,6 @@ nl:
         notice: "%{resource_name} is verwijderd."
       update:
         notice: "%{resource_name} is bijgewerkt."
+    playdates:
+      create:
+        notice: De nieuwe speeldag is toegevoegd.

--- a/config/locales/responders.nl.yml
+++ b/config/locales/responders.nl.yml
@@ -12,3 +12,5 @@ nl:
     playdates:
       create:
         notice: De nieuwe speeldag is toegevoegd.
+      destroy:
+        notice: De speeldag is verwijderd.

--- a/lib/application_responder.rb
+++ b/lib/application_responder.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ApplicationResponder < ActionController::Responder
+  include Responders::FlashResponder
+  include Responders::HttpCacheResponder
+
+  # Redirects resources to the collection path (index action) instead
+  # of the resource path (show action) for POST/PUT/DELETE requests.
+  # include Responders::CollectionResponder
+end

--- a/spec/controllers/playdates_controller_spec.rb
+++ b/spec/controllers/playdates_controller_spec.rb
@@ -65,37 +65,41 @@ RSpec.describe PlaydatesController, type: :controller do
     expect(response.body).to have_css "form[action=\"#{playdates_path}\"]"
   end
 
-  it "create" do
-    num_playdates = Playdate.count
+  describe "#create" do
+    it "create" do
+      num_playdates = Playdate.count
 
-    post "create", params: {playdate: {day: "2006-03-11"}}, session: adminsession
+      post "create", params: {playdate: {day: "2006-03-11"}}, session: adminsession
 
-    expect(response).to redirect_to controller: "playdates", action: "index"
+      aggregate_failures do
+        expect(response).to redirect_to controller: "playdates", action: "index"
+        expect(request).to set_flash[:notice].to I18n.t("flash.playdates.create.notice")
+        expect(Playdate.count).to eq num_playdates + 1
+      end
+    end
 
-    expect(Playdate.count).to eq num_playdates + 1
-  end
+    it "create_with_range" do
+      num_playdates = Playdate.count
 
-  it "create_with_range" do
-    num_playdates = Playdate.count
+      post "create", params: {period: 2, daytype: 6}, session: adminsession
 
-    post "create", params: {period: 2, daytype: 6}, session: adminsession
+      expect(response).to redirect_to controller: "playdates", action: "index"
 
-    expect(response).to redirect_to controller: "playdates", action: "index"
+      expect(Playdate.count).to be >= num_playdates + 4
+      expect(Playdate.count).to be <= num_playdates + 10
+    end
 
-    expect(Playdate.count).to be >= num_playdates + 4
-    expect(Playdate.count).to be <= num_playdates + 10
-  end
+    it "create_with_range_invalid_period" do
+      post "create", params: {period: 3, daytype: 6}, session: adminsession
 
-  it "create_with_range_invalid_period" do
-    post "create", params: {period: 3, daytype: 6}, session: adminsession
+      expect(response).to render_template :new
+    end
 
-    expect(response).to render_template :new
-  end
+    it "create_with_range_invalid_day_type" do
+      post "create", params: {period: 2, daytype: 7}, session: adminsession
 
-  it "create_with_range_invalid_day_type" do
-    post "create", params: {period: 2, daytype: 7}, session: adminsession
-
-    expect(response).to render_template :new
+      expect(response).to render_template :new
+    end
   end
 
   it "show" do

--- a/spec/controllers/players_controller_spec.rb
+++ b/spec/controllers/players_controller_spec.rb
@@ -93,8 +93,11 @@ RSpec.describe PlayersController, type: :controller do
       expect(assigns(:player)).not_to be_nil
     end
 
-    it "redirects to the player list" do
-      expect(response).to redirect_to players_path
+    it "redirects to the player list with a message" do
+      aggregate_failures do
+        expect(response).to redirect_to players_path
+        expect(request).to set_flash[:notice].to I18n.t("flash.players.create.notice")
+      end
     end
 
     it "increases the number of players" do
@@ -112,8 +115,11 @@ RSpec.describe PlayersController, type: :controller do
       post :destroy, params: {id: player.id}, session: adminsession
     end
 
-    it "redirects to the player list" do
-      expect(response).to redirect_to players_path
+    it "redirects to the player list with a message" do
+      aggregate_failures do
+        expect(response).to redirect_to players_path
+        expect(request).to set_flash[:notice].to I18n.t("flash.players.destroy.notice")
+      end
     end
 
     it "decreases the number of players" do
@@ -155,9 +161,12 @@ RSpec.describe PlayersController, type: :controller do
       expect(player).to have_received(:update).with(expected_params)
     end
 
-    it "redirects to the player list" do
+    it "redirects to the player list with a message" do
       post :update, params: {id: 1, player: player_params}, session: adminsession
-      expect(response).to redirect_to players_path
+      aggregate_failures do
+        expect(response).to redirect_to players_path
+        expect(request).to set_flash[:notice].to I18n.t("flash.players.update.notice")
+      end
     end
   end
 end


### PR DESCRIPTION
- Generate ApplicationResponder
- Normalize default flash translations
- Assume flash messages are used
- Provide Dutch version of default responders flash messages
- Remove now-superfluous calls to respond_to
- Let responders set the flash in PlaydatesController#create
- Let responders set the flash in PlaydatesController#destroy
- Use :alert key for error messages in the flash
- Let responders set the flash in PlayersController
- Let responders set the flash in AvailabilitiesController
- Regenerate RuboCop to-do file
