### PR TITLE
Drop psych requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem "will_paginate", "~> 3.3.0"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", "~> 1.15.0", require: false
-gem "psych", "~> 4.0", require: false
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development


### PR DESCRIPTION
Version 1.8.1 of bootsnap restored support for older versions of psych, so we can just use whatever version is the default.
