### PR TITLE
Fix new RuboCop offense

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development do
 
   gem "erb_lint", "~> 0.3.0", require: false
   gem "i18n-tasks", "~> 1.0", require: false
-  gem "rubocop", "~> 1.37", require: false
+  gem "rubocop", "~> 1.40", require: false
   gem "rubocop-performance", "~> 1.15", require: false
   gem "rubocop-rails", "~> 2.17", require: false
   gem "rubocop-rspec", "~> 2.14", require: false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"


### PR DESCRIPTION
- Update rubocop version to include Style/RedundantConstantBase
- Autocorrect Style/RedundantConstantBase offense
