### PR TITLE
Ensure new enough version of libyaml is available for i18n-tools

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,6 +37,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - run: |
+                wget http://mirrors.kernel.org/ubuntu/pool/main/liby/libyaml/libyaml-0-2_0.2.5-1_amd64.deb
+                sudo apt-get install ./libyaml-0-2_0.2.5-1_amd64.deb
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The default psych installation in GitHub Actions does not seem to use its embedded version of libyaml anymore. This means it uses the version provided by Ubuntu.

Since the version of libyaml provided in Ubuntu 22.04 is too old, the normalization check will fail due to differences in handling empty values.

By installing libyaml 0.2.5, the correct behavior is restored.
