### PR TITLE
Add brakeman action and fix warnings

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -51,3 +51,10 @@ jobs:
         run: bundle exec erblint --lint-all
       - name: Run i18n-tasks
         run: bundle exec i18n-tasks health
+
+  brakeman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Analyze code statically using Brakeman
+        uses: moneyforward/brakeman-action@v0

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -56,5 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: false
+      - name: Install brakeman gem
+        run: gem install brakeman
       - name: Analyze code statically using Brakeman
-        uses: moneyforward/brakeman-action@v0
+        run: brakeman

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ require "application_responder"
 
 # Main controller superclass.
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
   self.responder = ApplicationResponder
   respond_to :html
 

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -100,7 +100,7 @@
 #
 # See https://guides.rubyonrails.org/action_controller_overview.html#cookies
 # for more information.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json
 
 # Enable parameter wrapping for JSON.
 # Previously this was set in an initializer. It's fine to keep using that


### PR DESCRIPTION
- Add brakeman action to GitHub Actions
- Install and run brakeman directly
- Turn on request forgery protection
- Switch to the `:json` cookies serializer