### PR TITLE
Use default libyaml in lint job in GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,9 +37,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: |
-                wget http://mirrors.kernel.org/ubuntu/pool/main/liby/libyaml/libyaml-0-2_0.2.5-1_amd64.deb
-                sudo apt-get install ./libyaml-0-2_0.2.5-1_amd64.deb
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development do
   gem "web-console", "~> 4.0"
 
   gem "erb_lint", "~> 0.5.0", require: false
-  gem "i18n-tasks", "~> 1.0", require: false
+  gem "i18n-tasks", ["~> 1.0", ">= 1.0.13"], require: false
   gem "rubocop", "~> 1.56", require: false
   gem "rubocop-capybara", "~> 2.19", require: false
   gem "rubocop-performance", "~> 1.19", require: false


### PR DESCRIPTION
A version of i18n-tasks including https://github.com/glebm/i18n-tasks/pull/493 has been released so now we can drop the installation of a newer libyaml version.

- Require i18n-tasks version with uniform white space handling
- Use default libyaml in lint job in GitHub Actions
