### PR TITLE
Fix Turbo compatibility of create and update failure responses

### DIFF
--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -12,7 +12,7 @@ class CredentialsController < ApplicationController
     if @player.update(player_params)
       redirect_to(controller: "main", action: "index")
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/playdates_controller.rb
+++ b/app/controllers/playdates_controller.rb
@@ -51,12 +51,12 @@ class PlaydatesController < ApplicationController
   def save_new_range(period, daytype)
     unless [DAY_SATURDAY, DAY_FRIDAY].include?(daytype)
       flash.now[:notice] = t("playdates.alerts.invalid_day")
-      render :new
+      render :new, status: :unprocessable_entity
       return
     end
     unless [PERIOD_THIS_MONTH, PERIOD_NEXT_MONTH].include?(period)
       flash.now[:notice] = t("playdates.alerts.invalid_period")
-      render :new
+      render :new, status: :unprocessable_entity
       return
     end
 
@@ -67,7 +67,7 @@ class PlaydatesController < ApplicationController
       redirect_to action: "index"
     else
       flash.now[:notice] = t("playdates.notices.saved_none")
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -18,7 +18,7 @@ class SessionController < ApplicationController
       redirect_to(controller: "main", action: "index")
     else
       flash.now[:notice] = t(".failure")
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/lib/application_responder.rb
+++ b/lib/application_responder.rb
@@ -7,4 +7,8 @@ class ApplicationResponder < ActionController::Responder
   # Redirects resources to the collection path (index action) instead
   # of the resource path (show action) for POST/PUT/DELETE requests.
   # include Responders::CollectionResponder
+
+  # Use status codes compatible with Turbo.
+  self.error_status = :unprocessable_entity
+  self.redirect_status = :see_other
 end

--- a/spec/controllers/credentials_controller_spec.rb
+++ b/spec/controllers/credentials_controller_spec.rb
@@ -14,17 +14,28 @@ RSpec.describe CredentialsController, type: :controller do
     expect(response.body).to have_css "h1", text: "Wachtwoord wijzigen"
   end
 
-  it "update_password" do
-    post :update, params: {player: {password: "slurp", password_confirmation: "slurp"}}
-    expect(response).to redirect_to controller: "session", action: "new"
-    post :update,
-      params: {player: {password: "slurp", password_confirmation: "slurp"}},
-      session: playersession
-    expect(response).to redirect_to controller: "main", action: "index"
-    post :update,
-      params: {player: {password: "slu", password_confirmation: "slurp"}},
-      session: playersession
-    expect(response).to be_successful
+  describe "#update" do
+    it "requires login" do
+      post :update, params: {player: {password: "slurp", password_confirmation: "slurp"}}
+      expect(response).to redirect_to controller: "session", action: "new"
+    end
+
+    it "updates the password" do
+      matijs = players(:matijs)
+      post :update,
+        params: {player: {password: "slurp", password_confirmation: "slurp"}},
+        session: playersession
+      expect(response).to redirect_to controller: "main", action: "index"
+      expect(matijs.reload.check_password("slurp")).to be_truthy
+    end
+
+    it "renders edit on failures" do
+      post :update,
+        params: {player: {password: "slu", password_confirmation: "slurp"}},
+        session: playersession
+      expect(response).to render_template :edit
+      expect(response).to be_unprocessable
+    end
   end
 
   private

--- a/spec/controllers/playdates_controller_spec.rb
+++ b/spec/controllers/playdates_controller_spec.rb
@@ -106,13 +106,30 @@ RSpec.describe PlaydatesController, type: :controller do
     it "create_with_range_invalid_period" do
       post "create", params: {period: 3, daytype: 6}, session: adminsession
 
-      expect(response).to render_template :new
+      aggregate_failures do
+        expect(response).to render_template :new
+        expect(response).to be_unprocessable
+      end
     end
 
     it "create_with_range_invalid_day_type" do
       post "create", params: {period: 2, daytype: 7}, session: adminsession
 
-      expect(response).to render_template :new
+      aggregate_failures do
+        expect(response).to render_template :new
+        expect(response).to be_unprocessable
+      end
+    end
+
+    it "renders new with a message if no dates were created" do
+      post "create", params: {period: 2, daytype: 6}, session: adminsession
+      post "create", params: {period: 2, daytype: 6}, session: adminsession
+
+      aggregate_failures do
+        expect(response).to render_template :new
+        expect(response).to be_unprocessable
+        expect(response.body).to have_text I18n.t("playdates.notices.saved_none")
+      end
     end
   end
 

--- a/spec/controllers/playdates_controller_spec.rb
+++ b/spec/controllers/playdates_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe PlaydatesController, type: :controller do
   end
 
   describe "#create" do
-    it "create" do
+    it "can succesfully create a single date" do
       num_playdates = Playdate.count
 
       post "create", params: {playdate: {day: "2006-03-11"}}, session: adminsession
@@ -89,6 +89,17 @@ RSpec.describe PlaydatesController, type: :controller do
         expect(response).to redirect_to controller: "playdates", action: "index"
         expect(request).to set_flash[:notice].to I18n.t("flash.playdates.create.notice")
         expect(Playdate.count).to eq num_playdates + 1
+        expect(response).to have_http_status :see_other
+      end
+    end
+
+    it "renders new when date could not be created" do
+      Playdate.create! day: "2006-03-11"
+      post "create", params: {playdate: {day: "2006-03-11"}}, session: adminsession
+
+      aggregate_failures do
+        expect(response).to be_unprocessable
+        expect(response).to render_template :new
       end
     end
 

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -13,15 +13,22 @@ RSpec.describe SessionController, type: :controller do
     expect(response.body).to have_css "h1", text: "Inloggen in Playdate"
   end
 
-  it "login" do
+  it "login success" do
     matijs = players(:matijs)
     matijs.password = "gnoef!"
     matijs.password_confirmation = "gnoef!"
     matijs.save!
     post :create, params: {name: "matijs", password: "gnoef!"}
     expect(response).to redirect_to controller: "main", action: "index"
+  end
+
+  it "login failures" do
+    matijs = players(:matijs)
+    matijs.password = "gnoef!"
+    matijs.password_confirmation = "gnoef!"
+    matijs.save!
     post :create, params: {name: "matijs", password: "zonk"}
-    expect(response).to be_successful
+    expect(response).to be_unprocessable
     expect(response).to render_template "new"
   end
 


### PR DESCRIPTION
- Use status unprocessable_entity on date range creation failure
- Configure responders to be compatible with Turbo
- Use status unprocessable_entity on login failure
- Use status unprocessable_entity on password update failure
