### PR TITLE
Bump mimimum RuboCop versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Capybara/ClickLinkOrButtonStyle:
+  EnforcedStyle: strict
+
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,10 +81,6 @@ Performance/StartWith:
 RSpec/Rails/InferredSpecType:
   Enabled: false
 
-RSpec/Capybara/FeatureMethods:
-  Exclude:
-    - 'spec/features/**/*_spec.rb'
-
 # Require at least two dependent lines before suggesting a guard clause
 Style/GuardClause:
   MinBodyLength: 2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Rails:
 Capybara/ClickLinkOrButtonStyle:
   EnforcedStyle: strict
 
+Capybara/NegationMatcher:
+  EnforcedStyle: not_to
+
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,11 +48,11 @@ group :development do
 
   gem "erb_lint", "~> 0.5.0", require: false
   gem "i18n-tasks", ["~> 1.0", ">= 1.0.13"], require: false
-  gem "rubocop", "~> 1.56", require: false
-  gem "rubocop-capybara", "~> 2.19", require: false
-  gem "rubocop-performance", "~> 1.19", require: false
-  gem "rubocop-rails", "~> 2.21", require: false
-  gem "rubocop-rspec", "~> 2.24", require: false
+  gem "rubocop", "~> 1.60", require: false
+  gem "rubocop-capybara", "~> 2.20", require: false
+  gem "rubocop-performance", "~> 1.20", require: false
+  gem "rubocop-rails", "~> 2.23", require: false
+  gem "rubocop-rspec", "~> 2.26", require: false
 end
 
 group :test do


### PR DESCRIPTION
- Bump minimum rubocop gem versions
- Configure Capybara/ClickLinkOrButtonStyle
- Configure Capybara/NegationMatcher
- Remove needless exclusion for RSpec/Capybara/FeatureMethods
