### PR TITLE
Make RuboCop target Rails 7.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'bin/**/*'
   NewCops: enable
   TargetRubyVersion: 3.0
-  TargetRailsVersion: 6.1
+  TargetRailsVersion: 7.1
 
 Rails:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_mode:
     - Exclude
 
 require:
+  - rubocop-capybara
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec


### PR DESCRIPTION
- Bump RuboCop's target Rails version to 7.1
- Explicitly load rubocop-capybara
