### PR TITLE
Ensure range creation test will always create some playdates

### DIFF
--- a/spec/system/playdates_system_spec.rb
+++ b/spec/system/playdates_system_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Playdates system", type: :system do
+  include ActiveSupport::Testing::TimeHelpers
   fixtures :players, :playdates
 
   let(:admin) { players(:admin) }
@@ -25,15 +26,17 @@ RSpec.describe "Playdates system", type: :system do
   end
 
   it "enables the admin to create a range of playdates" do
-    click_link "Speeldagen"
-    old_count = Playdate.count
-    click_link "Nieuwe speeldag"
-    click_button "Reeks maken"
-    expect(page).to have_text "Tonen"
-    new_count = Playdate.count
-    created_count = new_count - old_count
-    expect(page)
-      .to have_text I18n.t("playdates.notices.saved_new_range", count: created_count)
+    travel_to Date.new(2024, 2, 10) do
+      click_link "Speeldagen"
+      old_count = Playdate.count
+      click_link "Nieuwe speeldag"
+      click_button "Reeks maken"
+      expect(page).to have_text "Tonen"
+      new_count = Playdate.count
+      created_count = new_count - old_count
+      expect(page)
+        .to have_text I18n.t("playdates.notices.saved_new_range", count: created_count)
+    end
   end
 
   it "enables the admin to clean up playdates" do


### PR DESCRIPTION
At the end of a month, attempting to create a range may result on no dates being added because there are no more Fridays or Saturdays in the month. To make this spec robust, travel to a fixed date where we know several new playdates will be added.
