### PR TITLE
Remove obsolete fix to prevent turbo from autoloading ActionCable

### DIFF
--- a/config/initializers/fix_turbo_loading.rb
+++ b/config/initializers/fix_turbo_loading.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-# Work around https://github.com/hotwired/turbo-rails/issues/512
-Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/channels")


### PR DESCRIPTION
Since version 2.0.6 of turbo-rails, this is no longer needed. See https://github.com/hotwired/turbo-rails/pull/601.
