### PR TITLE
Remove dynamic_form dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem "turbo-rails", "~> 2.0.6"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails", "~> 1.3.4"
 
-gem "dynamic_form", "~> 1.3.1"
 gem "propshaft", "~> 1.1.0"
 gem "responders", "~> 3.0"
 gem "will_paginate", "~> 4.0.0"

--- a/app/assets/stylesheets/playdate.css
+++ b/app/assets/stylesheets/playdate.css
@@ -118,7 +118,7 @@ a:hover { color: #fff; background-color:#000; }
   display: table;
 }
 
-#errorExplanation {
+.error_explanation {
   width: 400px;
   border: 2px solid red;
   padding: 7px;
@@ -127,7 +127,7 @@ a:hover { color: #fff; background-color:#000; }
   background-color: #f0f0f0;
 }
 
-#errorExplanation h2 {
+.error_explanation h2 {
   text-align: left;
   font-weight: bold;
   padding: 5px 5px 5px 15px;
@@ -137,13 +137,13 @@ a:hover { color: #fff; background-color:#000; }
   color: #fff;
 }
 
-#errorExplanation p {
+.error_explanation p {
   color: #333;
   margin-bottom: 0;
   padding: 5px;
 }
 
-#errorExplanation ul li {
+.error_explanation ul li {
   font-size: 12px;
   list-style: square;
 }

--- a/app/views/availabilities/new.html.erb
+++ b/app/views/availabilities/new.html.erb
@@ -4,7 +4,18 @@
 
 <div class="content">
   <%= form_for [@playdate, @availability] do %>
-    <%= error_messages_for "availability" %>
+    <% if @availability.errors.any? %>
+      <div class="error_explanation">
+        <h2><%= t("errors.template.header", model: "Speler", count: @availability.errors.count) %></h2>
+        <p><%= t("errors.template.body") %></p>
+
+        <ul>
+          <% @availability.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
     <p><label>Datum</label><br>
     <%= @playdate.day %></p>

--- a/app/views/playdates/_form.html.erb
+++ b/app/views/playdates/_form.html.erb
@@ -1,8 +1,17 @@
-<%= error_messages_for "playdate" %>
+<% if @playdate && @playdate.errors.any? %>
+  <div class="error_explanation">
+    <h2><%= t("errors.template.header", model: "Speler", count: @playdate.errors.count) %></h2>
+    <p><%= t("errors.template.body") %></p>
 
-<!--[form:playdate]-->
+    <ul>
+      <% @playdate.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <p>
 <label for="playdate_day">Dag:</label>
 <%= date_select "playdate", "day" %>
 </p>
-<!--[eoform:playdate]-->

--- a/app/views/players/edit.html.erb
+++ b/app/views/players/edit.html.erb
@@ -2,7 +2,18 @@
   Speler bewerken
 <% end %>
 
-<%= error_messages_for :player %>
+<% if @player.errors.any? %>
+  <div class="error_explanation">
+    <h2><%= t("errors.template.header", model: "Speler", count: @player.errors.count) %></h2>
+    <p><%= t("errors.template.body") %></p>
+
+    <ul>
+      <% @player.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
 <%= form_for(@player) do |f| %>
   <p>

--- a/app/views/players/new.html.erb
+++ b/app/views/players/new.html.erb
@@ -2,7 +2,18 @@
   Nieuwe speler
 <% end %>
 
-<%= error_messages_for :player %>
+<% if @player.errors.any? %>
+  <div class="error_explanation">
+    <h2><%= t("errors.template.header", model: "Speler", count: @player.errors.count) %></h2>
+    <p><%= t("errors.template.body") %></p>
+
+    <ul>
+      <% @player.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
 <%= form_for(@player) do |f| %>
   <p>


### PR DESCRIPTION
This removes the `dynamic_form` dependency and replaces use of `#error_messages_for` with ERB similar to Rails' default generated code.
