### PR TITLE
Use Rails' default session configuration

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Be sure to restart your server when you modify this file.
-
-Rails.application.config.session_store :cookie_store, key: "_playdate_session"


### PR DESCRIPTION
There is no need to configure this. Rails will use the cookie store with an appropriate key automatically.
