### PR TITLE
Update rubocop dependency versions and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,10 +22,10 @@ AllCops:
 Rails:
   Enabled: true
 
-Capybara/ClickLinkOrButtonStyle:
-  EnforcedStyle: strict
+Capybara/AmbiguousClick:
+  Enabled: true
 
-Capybara/NegationMatcher:
+Capybara/RSpec/NegationMatcher:
   EnforcedStyle: not_to
 
 Layout/ArgumentAlignment:

--- a/Gemfile
+++ b/Gemfile
@@ -52,11 +52,11 @@ group :development do
 
   gem "erb_lint", "~> 0.9.0", require: false
   gem "i18n-tasks", ["~> 1.0", ">= 1.0.13"], require: false
-  gem "rubocop", "~> 1.82", require: false
-  gem "rubocop-capybara", "~> 2.22", require: false
+  gem "rubocop", "~> 1.88", require: false
+  gem "rubocop-capybara", "~> 3.0", require: false
   gem "rubocop-performance", "~> 1.26", require: false
-  gem "rubocop-rails", "~> 2.34", require: false
-  gem "rubocop-rspec", "~> 3.9", require: false
+  gem "rubocop-rails", "~> 2.35", require: false
+  gem "rubocop-rspec", "~> 3.10", require: false
   gem "rubocop-rspec_rails", "~> 2.32", require: false
 end
 

--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -42,10 +42,10 @@ class AvailabilitiesController < ApplicationController
 
   def load_resource
     load_playdate
-    @availability = @playdate.availabilities.find(params[:id])
+    @availability = @playdate.availabilities.find(params.expect(:id))
   end
 
   def load_playdate
-    @playdate = Playdate.find(params[:playdate_id])
+    @playdate = Playdate.find(params.expect(:playdate_id))
   end
 end

--- a/app/controllers/playdates_controller.rb
+++ b/app/controllers/playdates_controller.rb
@@ -13,7 +13,7 @@ class PlaydatesController < ApplicationController
   end
 
   def show
-    @playdate = Playdate.find(params[:id])
+    @playdate = Playdate.find(params.expect(:id))
   end
 
   def new
@@ -35,7 +35,7 @@ class PlaydatesController < ApplicationController
   end
 
   def destroy
-    @playdate = Playdate.find(params[:id])
+    @playdate = Playdate.find(params.expect(:id))
     @playdate.destroy
     respond_with @playdate, location: playdates_path
   end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -12,7 +12,7 @@ class PlayersController < ApplicationController
   end
 
   def edit
-    @player = Player.find(params[:id])
+    @player = Player.find(params.expect(:id))
   end
 
   def create
@@ -22,13 +22,13 @@ class PlayersController < ApplicationController
   end
 
   def update
-    @player = Player.find(params[:id])
+    @player = Player.find(params.expect(:id))
     @player.update player_params
     respond_with @player, location: players_path
   end
 
   def destroy
-    @player = Player.find(params[:id])
+    @player = Player.find(params.expect(:id))
 
     if @player == current_user
       flash[:alert] = t(".cannot_delete_self")

--- a/spec/system/playdates_system_spec.rb
+++ b/spec/system/playdates_system_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Playdates system", type: :system do
   it "enables the admin to clean up playdates" do
     click_link "Speeldagen"
 
-    expect(page).to have_content "Speeldagen"
+    expect(page).to have_text "Speeldagen"
 
     accept_confirm do
       click_button "Opruimen"


### PR DESCRIPTION
- **Bump minimum version of rubocop dependencies**
- **Update configuration for latest rubocop-capybara version**
- **Autocorrect new offenses**
